### PR TITLE
Fix docker for relay_v1 and prepare for relay_v2

### DIFF
--- a/protocols/dcutr/Cargo.toml
+++ b/protocols/dcutr/Cargo.toml
@@ -33,3 +33,4 @@ libp2p-plaintext = { path = "../../transports/plaintext" }
 libp2p-relay = { version = "0.4", path = "../relay" }
 libp2p-yamux = { path = "../../muxers/yamux" }
 rand = "0.7"
+structopt = "0.3.21"

--- a/protocols/relay/examples/Dockerfile
+++ b/protocols/relay/examples/Dockerfile
@@ -1,19 +1,14 @@
 # 1: Build the exe
 FROM rust:1 as builder
 LABEL Name=libp2p-relay Version=0.0.1
-# 1a: Prepare for static linking
-RUN apt-get update && \
-    apt-get dist-upgrade -y && \
-    apt-get install -y musl-tools && \
-    rustup target add x86_64-unknown-linux-musl
+
 # 1b: Download and compile Rust dependencies (and store as a separate Docker layer)
 WORKDIR /usr/src/libp2p
 
 COPY . .
-RUN cargo build --target x86_64-unknown-linux-musl --example=relay --package=libp2p-relay
-
+RUN cargo build --example=relay_v? --package=libp2p-relay
 # 2: Copy the exe and extra files ("static") to an empty Docker image
 FROM debian:buster-slim
 
-COPY --from=builder /usr/src/libp2p/target/x86_64-unknown-linux-musl/debug/examples/relay .
+COPY --from=builder /usr/src/libp2p/target/debug/examples/relay_v? .
 USER 1000

--- a/protocols/relay/examples/docker-compose-relay_v1.yml
+++ b/protocols/relay/examples/docker-compose-relay_v1.yml
@@ -5,10 +5,10 @@ services:
   relay: 
     image: libp2p-relay
     command:
-      - "./relay"
+      - "./relay_v1"
       - "--mode=relay"
       - "--secret-key-seed=1"
-      - "--address=/ip6/::/tcp/4444"
+      - "--address=/ip4/0.0.0.0/tcp/4444"
     build:
       context: ../../../.
       dockerfile: ./protocols/relay/examples/Dockerfile
@@ -19,10 +19,10 @@ services:
   client-listen: 
     image: libp2p-relay
     command:
-      - "./relay"
+      - "./relay_v1"
       - "--mode=client-listen"
       - "--secret-key-seed=2"
-      - "--address=/dns6/relay/tcp/4444/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X/p2p-circuit"
+      - "--address=/dns4/relay/tcp/4444/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X/p2p-circuit"
     build:
       context: ../../../.
       dockerfile: ./protocols/relay/examples/Dockerfile
@@ -34,10 +34,10 @@ services:
   client-dial: 
     image: libp2p-relay
     command:
-      - "./relay"
+      - "./relay_v1"
       - "--mode=client-dial"
       - "--secret-key-seed=3"
-      - "--address=/dns6/relay/tcp/4444/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X/p2p-circuit/p2p/12D3KooWH3uVF6wv47WnArKHk5p6cvgCJEb74UTmxztmQDc298L3"
+      - "--address=/dns4/relay/tcp/4444/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X/p2p-circuit/p2p/12D3KooWH3uVF6wv47WnArKHk5p6cvgCJEb74UTmxztmQDc298L3"
     build:
       context: ../../../.
       dockerfile: ./protocols/relay/examples/Dockerfile
@@ -48,16 +48,4 @@ services:
       
 networks:
   network-a:
-    driver: bridge
-    enable_ipv6: true
-    ipam:
-      driver: default
-      config:
-        - subnet: 2001:3984:3989::/64
   network-b:
-    driver: bridge
-    enable_ipv6: true
-    ipam:
-      driver: default
-      config:
-        - subnet: 2001:3984:3988::/64

--- a/protocols/relay/examples/relay_v2.rs
+++ b/protocols/relay/examples/relay_v2.rs
@@ -22,19 +22,26 @@
 use futures::executor::block_on;
 use futures::stream::StreamExt;
 use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
-use libp2p::noise;
+use libp2p::multiaddr::Protocol;
 use libp2p::ping::{Ping, PingConfig, PingEvent};
 use libp2p::relay::v2::relay::{self, Relay};
 use libp2p::swarm::{Swarm, SwarmEvent};
 use libp2p::tcp::TcpConfig;
 use libp2p::Transport;
 use libp2p::{identity, NetworkBehaviour, PeerId};
+use libp2p::{noise, Multiaddr};
 use std::error::Error;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use structopt::StructOpt;
 
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let local_key = identity::Keypair::generate_ed25519();
+    let opt = Opt::from_args();
+    println!("opt: {:?}", opt);
+
+    // Create a static known PeerId based on given secret
+    let local_key: identity::Keypair = generate_ed25519(opt.secret_key_seed);
     let local_peer_id = PeerId::from(local_key.public());
     println!("Local peer id: {:?}", local_peer_id);
 
@@ -50,39 +57,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .multiplex(libp2p_yamux::YamuxConfig::default())
         .boxed();
 
-    #[derive(NetworkBehaviour)]
-    #[behaviour(out_event = "Event", event_process = false)]
-    struct Behaviour {
-        relay: Relay,
-        ping: Ping,
-        identify: Identify,
-    }
-
-    #[derive(Debug)]
-    enum Event {
-        Ping(PingEvent),
-        Identify(IdentifyEvent),
-        Relay(relay::Event),
-    }
-
-    impl From<PingEvent> for Event {
-        fn from(e: PingEvent) -> Self {
-            Event::Ping(e)
-        }
-    }
-
-    impl From<IdentifyEvent> for Event {
-        fn from(e: IdentifyEvent) -> Self {
-            Event::Identify(e)
-        }
-    }
-
-    impl From<relay::Event> for Event {
-        fn from(e: relay::Event) -> Self {
-            Event::Relay(e)
-        }
-    }
-
     let behaviour = Behaviour {
         relay: Relay::new(local_peer_id, Default::default()),
         ping: Ping::new(PingConfig::new()),
@@ -94,8 +68,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut swarm = Swarm::new(transport, behaviour, local_peer_id);
 
-    // Listen on all interfaces and whatever port the OS assigns
-    swarm.listen_on("/ip4/0.0.0.0/tcp/4001".parse()?)?;
+    // Listen on all interfaces
+    let listen_addr = Multiaddr::empty()
+        .with(match opt.use_ipv6 {
+            Some(true) => Protocol::from(Ipv6Addr::UNSPECIFIED),
+            _ => Protocol::from(Ipv4Addr::UNSPECIFIED),
+        })
+        .with(Protocol::Tcp(opt.port));
+    swarm.listen_on(listen_addr)?;
 
     block_on(async {
         loop {
@@ -110,4 +90,62 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     })
+}
+
+#[derive(NetworkBehaviour)]
+#[behaviour(out_event = "Event", event_process = false)]
+struct Behaviour {
+    relay: Relay,
+    ping: Ping,
+    identify: Identify,
+}
+
+#[derive(Debug)]
+enum Event {
+    Ping(PingEvent),
+    Identify(IdentifyEvent),
+    Relay(relay::Event),
+}
+
+impl From<PingEvent> for Event {
+    fn from(e: PingEvent) -> Self {
+        Event::Ping(e)
+    }
+}
+
+impl From<IdentifyEvent> for Event {
+    fn from(e: IdentifyEvent) -> Self {
+        Event::Identify(e)
+    }
+}
+
+impl From<relay::Event> for Event {
+    fn from(e: relay::Event) -> Self {
+        Event::Relay(e)
+    }
+}
+
+fn generate_ed25519(secret_key_seed: u8) -> identity::Keypair {
+    let mut bytes = [0u8; 32];
+    bytes[0] = secret_key_seed;
+
+    let secret_key = identity::ed25519::SecretKey::from_bytes(&mut bytes)
+        .expect("this returns `Err` only if the length is wrong; the length is correct; qed");
+    identity::Keypair::Ed25519(secret_key.into())
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "libp2p relay")]
+struct Opt {
+    /// Determine if the relay listen on ipv6 or ipv4 loopback address. the default is ipv4
+    #[structopt(long)]
+    use_ipv6: Option<bool>,
+
+    /// Fixed value to generate deterministic peer id
+    #[structopt(long)]
+    secret_key_seed: u8,
+
+    /// The port used to listen on all interfaces
+    #[structopt(long)]
+    port: u16,
 }

--- a/protocols/relay/examples/relay_v2.rs
+++ b/protocols/relay/examples/relay_v2.rs
@@ -21,7 +21,6 @@
 
 use futures::executor::block_on;
 use futures::stream::StreamExt;
-use libp2p::core::upgrade;
 use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
 use libp2p::noise;
 use libp2p::ping::{Ping, PingConfig, PingEvent};

--- a/protocols/relay/examples/relay_v2.rs
+++ b/protocols/relay/examples/relay_v2.rs
@@ -19,6 +19,51 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+//! A basic relay server version 2 implementation.
+//!
+//! The example below involves three nodes: (1) a relay server, (2) a listening
+//! dcutr-client listening via the relay server and (3) a dialing dcutr-client
+//! dialing the listening listening client via the relay server.
+//!
+//! 1. To start the relay server, run `cargo run --example=relay_v2 --package=libp2p-relay --secret-key-seed <seed number> --port <port number>`.
+//!    The `-secret-key-seed` helps create a static peer id using the given number argument as a seed.
+//!    The port specifies the port number used to listen for incoming requests with the loop back address. such as `/ip4/0.0.0.0/tcp/3333`.
+//!    IPV4 Example:
+//!    `cargo run --example=relay_v2 --package=libp2p-relay --secret-key-seed 1 --port 3333`
+//!
+//! 2. To start the dcutr-client run `cargo run --example=client --package=libp2p-dcutr --
+//! --mode listen --secret-key-seed <see number>
+//! --port <port number>
+//! --address <addr-relay-server>/p2p/<peer-id-relay-server>/p2p-circuit`
+//! -x <external ip address> in a second terminal where:
+//!
+//!   - `<addr-relay-server>` is replaced by one of the listening addresses of the relay server.
+//!   - `<peer-id-relay-server>` is replaced by the peer id of the relay server.
+//!
+//!    IPV4 local network example:
+//!    `cargo run --example=client --package=libp2p-dcutr --
+//! --mode listen
+//! --secret-key-seed 2
+//! --port 4444
+//! --address /ip4/127.0.0.1/tcp/3333/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X/p2p-circuit
+//! -x 111.212.22.134`
+//!
+//! 3. To start the dialing dcutr-client run `cargo run --example=client --package=libp2p-dcutr --
+//! --mode dial --secret-key-seed <see number>
+//! --port <port number>
+//! --address <addr-relay-server>/p2p/<peer-id-relay-server>/p2p-circuit`
+//! -x <external ip address> in a second terminal where:` in
+//! a third terminal where:
+//!
+//!   - `<addr-relay-server>` is replaced by one of the listening addresses of the relay server.
+//!   - `<peer-id-relay-server>` is replaced by the peer id of the relay server.
+//!   - `<peer-id-listening-relay-client>` is replaced by the peer id of the listening dcutr client.
+//!    IPV4 local network example:
+//!    `cargo run --example=client --package=libp2p-dcutr -- --mode dial --secret-key-seed 3 --port 5555 --address /ip4/127.0.0.1/tcp/3333/p2p/12D3KooWPjceQrSwdWXPyLLeABRXmuqt69Rg3sBYbU1Nft9HyQ6X/p2p-circuit/p2p/12D3KooWH3uVF6wv47WnArKHk5p6cvgCJEb74UTmxztmQDc298L3 -x 111.212.22.134`
+//!
+//! In the third terminal you will see the dialing dcutr client to receive pings
+//! from the listening dcutr client listener
+//!
 use futures::executor::block_on;
 use futures::stream::StreamExt;
 use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};

--- a/protocols/relay/src/v2/relay.rs
+++ b/protocols/relay/src/v2/relay.rs
@@ -128,7 +128,7 @@ pub enum Event {
         dst_peer_id: PeerId,
         error: std::io::Error,
     },
-    /// An inbound cirucit request has been accepted.
+    /// An inbound circuit request has been accepted.
     CircuitReqAccepted {
         src_peer_id: PeerId,
         dst_peer_id: PeerId,


### PR DESCRIPTION
One of the changes was from ipv6 to ipv4 since I notice that ipv6 is not fully supported and I want the example to be as simple as possible to beginner.
I also prepared the Docker to support docker compose of both relay versions.