### PR TITLE
protocols/relay/src/v2: Refactor error handling

### DIFF
--- a/misc/metrics/src/relay.rs
+++ b/misc/metrics/src/relay.rs
@@ -54,8 +54,10 @@ enum EventType {
     ReservationReqDenied,
     ReservationReqDenyFailed,
     ReservationTimedOut,
+    CircuitReqReceiveFailed,
     CircuitReqDenied,
     CircuitReqDenyFailed,
+    CircuitReqOutboundConnectFailed,
     CircuitReqAccepted,
     CircuitReqAcceptFailed,
     CircuitClosed,
@@ -79,7 +81,13 @@ impl From<&libp2p_relay::v2::relay::Event> for EventType {
             libp2p_relay::v2::relay::Event::ReservationTimedOut { .. } => {
                 EventType::ReservationTimedOut
             }
+            libp2p_relay::v2::relay::Event::CircuitReqReceiveFailed { .. } => {
+                EventType::CircuitReqReceiveFailed
+            }
             libp2p_relay::v2::relay::Event::CircuitReqDenied { .. } => EventType::CircuitReqDenied,
+            libp2p_relay::v2::relay::Event::CircuitReqOutboundConnectFailed { .. } => {
+                EventType::CircuitReqOutboundConnectFailed
+            }
             libp2p_relay::v2::relay::Event::CircuitReqDenyFailed { .. } => {
                 EventType::CircuitReqDenyFailed
             }

--- a/protocols/relay/src/v2/client.rs
+++ b/protocols/relay/src/v2/client.rs
@@ -23,7 +23,7 @@
 mod handler;
 pub mod transport;
 
-use crate::v2::protocol::{self, inbound_stop};
+use crate::v2::protocol::{self, inbound_stop, outbound_hop};
 use bytes::Bytes;
 use futures::channel::mpsc::Receiver;
 use futures::channel::oneshot;
@@ -36,6 +36,7 @@ use libp2p_core::{Multiaddr, PeerId};
 use libp2p_swarm::dial_opts::DialOpts;
 use libp2p_swarm::{
     NegotiatedSubstream, NetworkBehaviour, NetworkBehaviourAction, NotifyHandler, PollParameters,
+    ProtocolsHandlerUpgrErr,
 };
 use std::collections::{hash_map, HashMap, VecDeque};
 use std::io::{Error, IoSlice};
@@ -57,6 +58,7 @@ pub enum Event {
         relay_peer_id: PeerId,
         /// Indicates whether the request replaces an existing reservation.
         renewal: bool,
+        error: ProtocolsHandlerUpgrErr<outbound_hop::ReservationFailedReason>,
     },
     OutboundCircuitEstablished {
         relay_peer_id: PeerId,
@@ -64,16 +66,19 @@ pub enum Event {
     },
     OutboundCircuitReqFailed {
         relay_peer_id: PeerId,
+        error: ProtocolsHandlerUpgrErr<outbound_hop::CircuitFailedReason>,
     },
     /// An inbound circuit has been established.
     InboundCircuitEstablished {
         src_peer_id: PeerId,
         limit: Option<protocol::Limit>,
     },
-    /// An inbound circuit request has been denied.
-    InboundCircuitReqDenied {
-        src_peer_id: PeerId,
+    InboundCircuitReqFailed {
+        relay_peer_id: PeerId,
+        error: ProtocolsHandlerUpgrErr<void::Void>,
     },
+    /// An inbound circuit request has been denied.
+    InboundCircuitReqDenied { src_peer_id: PeerId },
     /// Denying an inbound circuit request failed.
     InboundCircuitReqDenyFailed {
         src_peer_id: PeerId,
@@ -169,15 +174,15 @@ impl NetworkBehaviour for Client {
                         limit,
                     },
                 )),
-            handler::Event::ReservationReqFailed { renewal } => {
-                self.queued_actions
-                    .push_back(NetworkBehaviourAction::GenerateEvent(
-                        Event::ReservationReqFailed {
-                            relay_peer_id: event_source,
-                            renewal,
-                        },
-                    ))
-            }
+            handler::Event::ReservationReqFailed { renewal, error } => self
+                .queued_actions
+                .push_back(NetworkBehaviourAction::GenerateEvent(
+                    Event::ReservationReqFailed {
+                        relay_peer_id: event_source,
+                        renewal,
+                        error,
+                    },
+                )),
             handler::Event::OutboundCircuitEstablished { limit } => {
                 self.queued_actions
                     .push_back(NetworkBehaviourAction::GenerateEvent(
@@ -187,11 +192,12 @@ impl NetworkBehaviour for Client {
                         },
                     ))
             }
-            handler::Event::OutboundCircuitReqFailed {} => {
+            handler::Event::OutboundCircuitReqFailed { error } => {
                 self.queued_actions
                     .push_back(NetworkBehaviourAction::GenerateEvent(
                         Event::OutboundCircuitReqFailed {
                             relay_peer_id: event_source,
+                            error,
                         },
                     ))
             }
@@ -200,6 +206,15 @@ impl NetworkBehaviour for Client {
                 .push_back(NetworkBehaviourAction::GenerateEvent(
                     Event::InboundCircuitEstablished { src_peer_id, limit },
                 )),
+            handler::Event::InboundCircuitReqFailed { error } => {
+                self.queued_actions
+                    .push_back(NetworkBehaviourAction::GenerateEvent(
+                        Event::InboundCircuitReqFailed {
+                            relay_peer_id: event_source,
+                            error,
+                        },
+                    ))
+            }
             handler::Event::InboundCircuitReqDenied { src_peer_id } => self
                 .queued_actions
                 .push_back(NetworkBehaviourAction::GenerateEvent(

--- a/protocols/relay/src/v2/relay.rs
+++ b/protocols/relay/src/v2/relay.rs
@@ -121,6 +121,10 @@ pub enum Event {
     },
     /// An inbound reservation has timed out.
     ReservationTimedOut { src_peer_id: PeerId },
+    CircuitReqReceiveFailed {
+        src_peer_id: PeerId,
+        error: ProtocolsHandlerUpgrErr<void::Void>,
+    },
     /// An inbound circuit request has been denied.
     CircuitReqDenied {
         src_peer_id: PeerId,
@@ -434,6 +438,15 @@ impl NetworkBehaviour for Relay {
                     }
                 };
                 self.queued_actions.push_back(action.into());
+            }
+            handler::Event::CircuitReqReceiveFailed { error } => {
+                self.queued_actions.push_back(
+                    NetworkBehaviourAction::GenerateEvent(Event::CircuitReqReceiveFailed {
+                        src_peer_id: event_source,
+                        error,
+                    })
+                    .into(),
+                );
             }
             handler::Event::CircuitReqDenied {
                 circuit_id,


### PR DESCRIPTION
Does the following changes:

- Distinguishes between fatal and non-fatal errors within `v2/protocol/*`.
- Emits fatal errors via `ProtocolsHandlerEvent::Close` not attempting to emit events to the `NetworkBehaviour` or `Transport` before closing
- Emits non-fatal errors via `ProtocolsHandler::OutEvent` and consecutively via `NetworkBehaviour::OutEvent`.
